### PR TITLE
Implemented pointer-stmt parser

### DIFF
--- a/docs/sphinx/conformance.rst
+++ b/docs/sphinx/conformance.rst
@@ -91,7 +91,6 @@ current list includes:
 * *form-team-stmt*
 * *generic-stmt*
 * *lock-stmt*
-* *pointer-stmt*
 * *protected-stmt*
 * *submodule*
 * *sync-all-stmt*

--- a/src/flpr/Syntax_Tags_Defs.hh
+++ b/src/flpr/Syntax_Tags_Defs.hh
@@ -483,6 +483,8 @@
   X(SG_PARENT_STRING, "parent-string", 1)                               \
   X(SG_PART_REF, "part-ref", 1)                                         \
   X(SG_POINTER_ASSIGNMENT_STMT, "pointer-assignment-stmt", 1)           \
+  X(SG_POINTER_DECL, "pointer-decl", 1)                                 \
+  X(SG_POINTER_DECL_LIST, "pointer-decl-list", 1)                       \
   X(SG_POINTER_OBJECT, "pointer-object", 1)                             \
   X(SG_POINTER_OBJECT_LIST, "pointer-object-list", 1)                   \
   X(SG_POINTER_STMT, "pointer-stmt", 1)                                 \

--- a/src/flpr/parse_stmt.cc
+++ b/src/flpr/parse_stmt.cc
@@ -2428,7 +2428,7 @@ Stmt_Tree other_specification_stmt(TT_Stream &ts) {
          rule(intrinsic_stmt),
          rule(namelist_stmt),
          rule(optional_stmt),
-         // FIX rule(pointer_stmt),
+         rule(pointer_stmt),
          // FIX rule(protected_stmt),
          rule(save_stmt),
          rule(target_stmt),
@@ -2521,6 +2521,17 @@ Stmt_Tree pointer_assignment_stmt(TT_Stream &ts) {
   EVAL(SG_POINTER_ASSIGNMENT_STMT, p(ts));
 }
 
+//! R854: pointer-decl (8.6.12)
+Stmt_Tree pointer_decl(TT_Stream &ts) {
+  RULE(SG_POINTER_DECL);
+  constexpr auto p =
+    seq(rule_tag,
+        name(),  // object-name or proc-entity-name
+        opt(h_parens(h_list(TOK(TK_COLON)))) // deferred-shape-spec-list
+        );
+  EVAL(SG_POINTER_DECL, p(ts));
+}
+
 //! R939: pointer-object (9.7.2)
 Stmt_Tree pointer_object(TT_Stream &ts) {
   RULE(SG_POINTER_OBJECT);
@@ -2531,6 +2542,20 @@ Stmt_Tree pointer_object(TT_Stream &ts) {
          // proc-pointer-name (equiv to previous alt)
          );
   EVAL(SG_POINTER_OBJECT, p(ts));
+}
+
+//! R853: pointer-stmt (8.6.12)
+Stmt_Tree pointer_stmt(TT_Stream &ts) {
+  RULE(SG_POINTER_STMT);
+  constexpr auto p =
+    seq(rule_tag,
+        TOK(KW_POINTER),
+        opt(TOK(TK_DBL_COLON)),
+        list(TAG(SG_POINTER_DECL_LIST),
+             rule(pointer_decl)),
+        eol()
+        );
+  EVAL(SG_POINTER_STMT, p(ts));
 }
 
 //! R1526: prefix (15.6.2.1)
@@ -3648,7 +3673,7 @@ Stmt_Tree parse_stmt_dispatch(int stmt_tag, TT_Stream &ts) {
     return pointer_assignment_stmt(ts);
     break;
   case TAG(SG_POINTER_STMT):
-    assert(0); /* return pointer_stmt(ts); */
+    return pointer_stmt(ts);
     break;
   case TAG(SG_PRINT_STMT):
     return print_stmt(ts);

--- a/tests/test_parse_stmt.cc
+++ b/tests/test_parse_stmt.cc
@@ -377,6 +377,16 @@ bool pointer_assignment_stmt() {
   return true;
 }
 
+bool pointer_stmt() {
+  TSS(pointer_stmt, "pointer a");
+  TSS(pointer_stmt, "pointer a,b");
+  TSS(pointer_stmt, "pointer :: a");
+  TSS(pointer_stmt, "pointer :: a,b");
+  TSS(pointer_stmt, "pointer a(:),b");
+  TSS(pointer_stmt, "pointer::a(:,:),b(:)");
+  return true;
+}
+
 bool print_stmt() {
   TSS(print_stmt, "print *, foo");
   TSS(print_stmt, "print 100, foo");


### PR DESCRIPTION
Addresses issue #4:
- Added pointer-decl and pointer-decl-list to Syntax_Tags
- Added pointer_decl() and pointer_stmt() to parse_stmt.cc
- Added a pointer_stmt() unit test to test_parse_stmt.cc
- Removed pointer-stmt from todo list in conformance.rst