### PR TITLE
Implemented fail-image-stmt parser, issue #21

### DIFF
--- a/docs/sphinx/conformance.rst
+++ b/docs/sphinx/conformance.rst
@@ -84,7 +84,6 @@ current list includes:
 * *critical-construct*
 * *event-post-stmt*
 * *event-wait-stmt*
-* *fail-image-stmt*
 * *form-team-stmt*
 * *lock-stmt*
 * *submodule*

--- a/src/flpr/Syntax_Tags_Defs.hh
+++ b/src/flpr/Syntax_Tags_Defs.hh
@@ -100,6 +100,7 @@
   X(KW_EXIT, "EXIT", 4)                                                 \
   X(KW_EXTENDS, "EXTENDS", 4)                                           \
   X(KW_EXTERNAL, "EXTERNAL", 4)                                         \
+  X(KW_FAIL, "FAIL", 4)                                                 \
   X(KW_FILE, "FILE", 4)                                                 \
   X(KW_FINAL, "FINAL", 4)                                               \
   X(KW_FLUSH, "FLUSH", 4)                                               \
@@ -110,6 +111,7 @@
   X(KW_GENERIC, "GENERIC", 4)                                           \
   X(KW_GO, "GO", 4)                                                     \
   X(KW_IF, "IF", 4)                                                     \
+  X(KW_IMAGE, "IMAGE", 4)                                               \
   X(KW_IMPLICIT, "IMPLICIT", 4)                                         \
   X(KW_IMPORT, "IMPORT", 4)                                             \
   X(KW_IMPURE, "IMPURE", 4)                                             \

--- a/src/flpr/parse_stmt.cc
+++ b/src/flpr/parse_stmt.cc
@@ -193,7 +193,7 @@ Stmt_Tree action_stmt(TT_Stream &ts) {
          // FIX rule(event_post_stmt),
          // FIX rule(event_wait_stmt),
          rule(exit_stmt),
-         // FIX rule(fail_image_stmt),
+         rule(fail_image_stmt),
          rule(flush_stmt),
          // FIX rule(form_team_stmt),
          rule(goto_stmt),
@@ -1714,6 +1714,17 @@ Stmt_Tree external_stmt(TT_Stream &ts) {
 }
 
 /* I:F */
+
+//! R1163: fail-image-stmt (11.5)
+Stmt_Tree fail_image_stmt(TT_Stream &ts) {
+  RULE(SG_FAIL_IMAGE_STMT);
+  constexpr auto p =
+    seq(rule_tag,
+        TOK(KW_FAIL),
+        TOK(KW_IMAGE),
+        eol());
+  EVAL(SG_FAIL_IMAGE_STMT, p(ts));
+}
 
 //! R753: final-procedure-stmt (7.5.6.1)
 Stmt_Tree final_procedure_stmt(TT_Stream &ts) {
@@ -3715,9 +3726,7 @@ Stmt_Tree parse_stmt_dispatch(int stmt_tag, TT_Stream &ts) {
     return external_stmt(ts);
     break;
   case TAG(SG_FAIL_IMAGE_STMT):
-    std::cerr << "Error: no parser for SG_FAIL_IMAGE_STMT" << std::endl;
-    return Stmt_Tree();
-    /* return fail_image_stmt(ts); */
+    return fail_image_stmt(ts); 
     break;
   case TAG(SG_FLUSH_STMT):
     return flush_stmt(ts);

--- a/src/flpr/scan_fort.l
+++ b/src/flpr/scan_fort.l
@@ -71,6 +71,7 @@ error { return Syntax_Tags::KW_ERROR; }
 exit { return Syntax_Tags::KW_EXIT; }
 extends { return Syntax_Tags::KW_EXTENDS; }
 external { return Syntax_Tags::KW_EXTERNAL; }
+fail { return Syntax_Tags::KW_FAIL; }
 file { return Syntax_Tags::KW_FILE; }
 final { return Syntax_Tags::KW_FINAL; }
 flush { return Syntax_Tags::KW_FLUSH; }
@@ -81,6 +82,7 @@ function { return Syntax_Tags::KW_FUNCTION; }
 generic { return Syntax_Tags::KW_GENERIC; }
 go  { return Syntax_Tags::KW_GO; }
 if { return Syntax_Tags::KW_IF; }
+image { return Syntax_Tags::KW_IMAGE; }
 implicit { return Syntax_Tags::KW_IMPLICIT; }
 import { return Syntax_Tags::KW_IMPORT; }
 impure { return Syntax_Tags::KW_IMPURE; }

--- a/tests/test_parse_stmt.cc
+++ b/tests/test_parse_stmt.cc
@@ -289,6 +289,11 @@ bool external_stmt() {
   return true;
 }
 
+bool fail_image_stmt() {
+  TSS(fail_image_stmt, "FAIL image");
+  return true;
+}
+
 bool forall_construct_stmt() {
   TSS(forall_construct_stmt, "forall(i=1:strln)");
   FSS(forall_stmt, "forall(i=1:strln)");
@@ -577,6 +582,7 @@ int main() {
   TEST(entry_stmt);
   TEST(exit_stmt);
   TEST(external_stmt);
+  TEST(fail_image_stmt);
   TEST(forall_construct_stmt);
   TEST(format_stmt);
   TEST(function_stmt);


### PR DESCRIPTION
- Added FAIL and IMAGE to scanner and Syntax_Tags
- Added the fail-image-stmt parser
- Added a trivial test
- Updated Sphinx documentation