### PR TITLE
Implemented lock-stmt and unlock-stmt parsers

### DIFF
--- a/docs/sphinx/conformance.rst
+++ b/docs/sphinx/conformance.rst
@@ -85,9 +85,7 @@ current list includes:
 * *event-post-stmt*
 * *event-wait-stmt*
 * *form-team-stmt*
-* *lock-stmt*
 * *submodule*
-* *unlock-stmt*
 * *wait-stmt*  
 
 These will be implemented soon, but if one in particular is holding

--- a/src/flpr/Syntax_Tags_Defs.hh
+++ b/src/flpr/Syntax_Tags_Defs.hh
@@ -57,6 +57,7 @@
   X(HOIST, "<HOIST>", 0)                                                \
   X(KW_000_LB, "<keyword grammar enum lower bound>", 0)                 \
   X(KW_ABSTRACT, "ABSTRACT", 4)                                         \
+  X(KW_ACQUIRED_LOCK, "ACQUIRED_LOCK", 4)                               \
   X(KW_ALL, "ALL", 4)                                                   \
   X(KW_ALLOCATABLE, "ALLOCATABLE", 4)                                   \
   X(KW_ALLOCATE, "ALLOCATE", 4)                                         \
@@ -129,6 +130,7 @@
   X(KW_LEN, "LEN", 4)                                                   \
   X(KW_LOCAL, "LOCAL", 4)                                               \
   X(KW_LOCAL_INIT, "LOCAL_INIT", 4)                                     \
+  X(KW_LOCK, "LOCK", 4)                                                 \
   X(KW_LOGICAL, "LOGICAL", 4)                                           \
   X(KW_MEMORY, "MEMORY", 4)                                             \
   X(KW_MODULE, "MODULE", 4)                                             \
@@ -182,6 +184,7 @@
   X(KW_TO, "TO", 4)                                                     \
   X(KW_TYPE, "TYPE", 4)                                                 \
   X(KW_UNFORMATTED, "UNFORMATTED", 4)                                   \
+  X(KW_UNLOCK, "UNLOCK", 4)                                             \
   X(KW_USE, "USE", 4)                                                   \
   X(KW_VALUE, "VALUE", 4)                                               \
   X(KW_VOLATILE, "VOLATILE", 4)                                         \

--- a/src/flpr/scan_fort.l
+++ b/src/flpr/scan_fort.l
@@ -28,6 +28,7 @@ EXPONENT     [ed][-+]?{DIGIT}+
 %%
   /* Keywords */
 abstract { return Syntax_Tags::KW_ABSTRACT; }
+acquired_lock { return Syntax_Tags::KW_ACQUIRED_LOCK; }
 all { return Syntax_Tags::KW_ALL; }
 allocatable { return Syntax_Tags::KW_ALLOCATABLE; }
 allocate { return Syntax_Tags::KW_ALLOCATE; }
@@ -100,6 +101,7 @@ kind { return Syntax_Tags::KW_KIND; }
 len { return Syntax_Tags::KW_LEN; }
 local { return Syntax_Tags::KW_LOCAL; }
 local_init { return Syntax_Tags::KW_LOCAL_INIT; }
+lock { return Syntax_Tags::KW_LOCK; }
 logical { return Syntax_Tags::KW_LOGICAL; }
 memory { return Syntax_Tags::KW_MEMORY; }
 module { return Syntax_Tags::KW_MODULE; }
@@ -153,6 +155,7 @@ then { return Syntax_Tags::KW_THEN; }
 to { return Syntax_Tags::KW_TO; }
 type { return Syntax_Tags::KW_TYPE; }
 unformatted { return Syntax_Tags::KW_UNFORMATTED; }
+unlock { return Syntax_Tags::KW_UNLOCK; }
 use { return Syntax_Tags::KW_USE; }
 value { return Syntax_Tags::KW_VALUE; }
 volatile { return Syntax_Tags::KW_VOLATILE; }

--- a/tests/test_parse_stmt.cc
+++ b/tests/test_parse_stmt.cc
@@ -388,6 +388,13 @@ bool interface_stmt() {
   return true;
 }
 
+bool lock_stmt() {
+  TSS(lock_stmt, "lock (var)");
+  TSS(lock_stmt, "lock (var, acquired_lock=al(i), errmsg=foo(1))");
+  TSS(lock_stmt, "lock (var(i),  errmsg=errvar(i))");
+  return true;
+}
+
 bool masked_elsewhere_stmt() {
   TSS(masked_elsewhere_stmt, "else where (a < 3)");
   TSS(masked_elsewhere_stmt, "elsewhere (a < 3)");
@@ -550,6 +557,13 @@ bool use_stmt() {
   return true;
 }
 
+bool unlock_stmt() {
+  TSS(unlock_stmt, "unlock (var)");
+  TSS(unlock_stmt, "unlock (var, errmsg=foo(1))");
+  TSS(unlock_stmt, "unlock (var(i),  errmsg=errvar(i))");
+  return true;
+}
+
 bool value_stmt() {
   TSS(value_stmt, "value a");
   TSS(value_stmt, "value :: a");
@@ -629,6 +643,7 @@ int main() {
   TEST(inquire_stmt);
   TEST(intent_stmt);
   TEST(interface_stmt);
+  TEST(lock_stmt);
   TEST(masked_elsewhere_stmt);
   TEST(namelist_stmt);
   TEST(parameter_stmt);
@@ -648,6 +663,7 @@ int main() {
   // test_type_declaration_stmt is handled in test_parse_type_decl.cc
   TEST(type_bound_generic_stmt);
   TEST(type_bound_proc_binding);
+  TEST(unlock_stmt);
   TEST(use_stmt);
   TEST(value_stmt);
   TEST(where_construct_stmt);


### PR DESCRIPTION
- Added LOCK, UNLOCK, and ACQUIRED_LOCK to scanner and Syntax_Tags
- added parsers and tests
- Updated documentation
Bug fix: made sync-team-stmt part of action-stmt (it was commented out)