### PR TITLE
Improve facilities for handling Syntax_Tags client extensions

### DIFF
--- a/apps/ext_demo.cc
+++ b/apps/ext_demo.cc
@@ -67,6 +67,15 @@ int main() {
      specially */
   exts.clear();
   exts.register_action_stmt(FLPR::Stmt::write_comma_stmt_mytag);
+
+  /* If you are printing out the syntax tree, as in this example, you can
+     register a label and a type (see Syntax_Tags_Defs.hh for a description of
+     types) that make the output prettier.  If you don't do this optional step,
+     your extension tag will come with a default label of
+     "<client-extension+N>", where N is an integer offset from the
+     Syntax_Tags::CLIENT_EXTENSION tag. Syntax tag extension registration looks
+     like: */
+  FLPR::Syntax_Tags::register_ext(MY_WRITE_STMT, "my-write-stmt", 5);
   std::cout << "Extended ";
   parse_executable_construct(lf_comma);
 

--- a/apps/flpr_show_cst.cc
+++ b/apps/flpr_show_cst.cc
@@ -86,7 +86,7 @@ int main() {
     for (int sg_id = FLPR::Syntax_Tags::SG_000_LB + 1;
          sg_id < FLPR::Syntax_Tags::SG_ZZZ_UB; ++sg_id) {
       /* ...looking for top-level stmt parsers... */
-      if (FLPR::Syntax_Tags::types[sg_id] == 5) {
+      if (FLPR::Syntax_Tags::type(sg_id) == 5) {
         FLPR::Stmt::Stmt_Tree st = FLPR::Stmt::parse_stmt_dispatch(sg_id, ts);
         /* ... that accept this input. */
         if (st) {

--- a/src/flpr/CMakeLists.txt
+++ b/src/flpr/CMakeLists.txt
@@ -29,6 +29,7 @@ set(Libflpr_SRCS
   Prgm_Tree.cc
   Stmt_Parser_Exts.cc
   Stmt_Tree.cc
+  Syntax_Tags.cc
   Token_Text.cc
   TT_Stream.cc
   parse_stmt.cc

--- a/src/flpr/Syntax_Tags.cc
+++ b/src/flpr/Syntax_Tags.cc
@@ -1,0 +1,39 @@
+#include "Syntax_Tags.hh"
+#include <cassert>
+
+/* Declare the static member variable */
+std::vector<FLPR::Syntax_Tags::Ext_Record> FLPR::Syntax_Tags::extensions_;
+
+std::string FLPR::Syntax_Tags::label(int const syntag) {
+  const int ext_idx = get_ext_idx_(syntag);
+  if (ext_idx == -2)
+    return strings_[syntag];
+  if (ext_idx == -1) {
+    std::string tmp =
+        "<client-extension+" + std::to_string(syntag - CLIENT_EXTENSION) + '>';
+    return tmp;
+  }
+  return extensions_[ext_idx].label;
+}
+
+int FLPR::Syntax_Tags::type(int const syntag) {
+  const int ext_idx = get_ext_idx_(syntag);
+  if (ext_idx == -2)
+    return types_[syntag];
+  if (ext_idx == -1)
+    return 4;
+  return extensions_[ext_idx].type;
+}
+
+bool FLPR::Syntax_Tags::register_ext(int const tag_idx, char const *const label,
+                                     int const type) {
+  assert(tag_idx >= CLIENT_EXTENSION);
+  const size_t ext_idx = static_cast<size_t>(tag_idx - CLIENT_EXTENSION);
+  if (extensions_.size() <= ext_idx) {
+    extensions_.resize(ext_idx + 1);
+  }
+  assert(extensions_[ext_idx].empty());
+  extensions_[ext_idx].label = std::string(label);
+  extensions_[ext_idx].type = type;
+  return true;
+}

--- a/tests/test_syntag_sanity.cc
+++ b/tests/test_syntag_sanity.cc
@@ -36,7 +36,7 @@ bool tag_bounds() {
 bool kw_type() {
   for (int i = FLPR::Syntax_Tags::KW_000_LB + 1;
        i < FLPR::Syntax_Tags::KW_ZZZ_UB; ++i) {
-    TEST_INT_LABEL(FLPR::Syntax_Tags::label(i), FLPR::Syntax_Tags::types[i], 4);
+    TEST_INT_LABEL(FLPR::Syntax_Tags::label(i), FLPR::Syntax_Tags::type(i), 4);
   }
   return true;
 }
@@ -48,9 +48,9 @@ bool sg_stmt_type() {
     auto pos = label.find_last_of('-');
     std::string last_term = label.substr(pos + 1);
     if (last_term == "stmt") {
-      TEST_INT_LABEL(label, FLPR::Syntax_Tags::types[i], 5);
+      TEST_INT_LABEL(label, FLPR::Syntax_Tags::type(i), 5);
     } else {
-      TEST_OR_INT_LABEL(label, FLPR::Syntax_Tags::types[i], 1, 2);
+      TEST_OR_INT_LABEL(label, FLPR::Syntax_Tags::type(i), 1, 2);
     }
   }
   return true;
@@ -59,8 +59,24 @@ bool sg_stmt_type() {
 bool tk_type() {
   for (int i = FLPR::Syntax_Tags::TK_000_LB + 1;
        i < FLPR::Syntax_Tags::TK_ZZZ_UB; ++i) {
-    TEST_INT_LABEL(FLPR::Syntax_Tags::label(i), FLPR::Syntax_Tags::types[i], 3);
+    TEST_INT_LABEL(FLPR::Syntax_Tags::label(i), FLPR::Syntax_Tags::type(i), 3);
   }
+  return true;
+}
+
+bool ext_test() {
+  const int ext_tag1 = FLPR::Syntax_Tags::CLIENT_EXTENSION;
+  const int ext_tag2 = ext_tag1 + 1;
+  const int ext_tag3 = ext_tag1 + 2;
+  // the registration order shouldn't matter
+  FLPR::Syntax_Tags::register_ext(ext_tag3, "mytag3", 5);
+  FLPR::Syntax_Tags::register_ext(ext_tag1, "mytag1", 1);
+  TEST_INT(FLPR::Syntax_Tags::type(ext_tag1), 1);
+  TEST_INT(FLPR::Syntax_Tags::type(ext_tag2), 4); // default for unassigned
+  TEST_INT(FLPR::Syntax_Tags::type(ext_tag3), 5);
+  TEST_STR("mytag1", FLPR::Syntax_Tags::label(ext_tag1));
+  TEST_STR("<client-extension+1>", FLPR::Syntax_Tags::label(ext_tag2));
+  TEST_STR("mytag3", FLPR::Syntax_Tags::label(ext_tag3));
   return true;
 }
 
@@ -68,5 +84,8 @@ int main() {
   TEST_MAIN_DECL;
   TEST(tag_bounds);
   TEST(sg_stmt_type);
+  TEST(kw_type);
+  TEST(tk_type);
+  TEST(ext_test);
   TEST_MAIN_REPORT;
 }


### PR DESCRIPTION
This PR adds some facilities that allows a FLPR client to register labels and types for their Syntax_Tags extensions, improving readability of tree dumps.