### PR TITLE
Added new type-decl-attr-seq rule

### DIFF
--- a/src/flpr/Syntax_Tags_Defs.hh
+++ b/src/flpr/Syntax_Tags_Defs.hh
@@ -584,6 +584,7 @@
   X(SG_TYPE_BOUND_PROC_BINDING, "type-bound-proc-binding", 1)           \
   X(SG_TYPE_BOUND_PROC_DECL, "type-bound-proc-decl", 1)                 \
   X(SG_TYPE_BOUND_PROC_DECL_LIST, "type-bound-proc-decl-list", 1)       \
+  X(SG_TYPE_DECL_ATTR_SEQ, "type-decl-attr-seq", 1)                     \
   X(SG_TYPE_DECLARATION_STMT, "type-declaration-stmt", 5)               \
   X(SG_TYPE_GUARD_STMT, "type-guard-stmt", 5)                           \
   X(SG_TYPE_PARAM_ATTR_SPEC, "type-param-attr-spec", 1)                 \

--- a/tests/parse_helpers.hh
+++ b/tests/parse_helpers.hh
@@ -26,8 +26,8 @@ inline bool expect_tag(Syntax_Tags::Tags const expected_val, int const test_val,
                        int const linenum) {
   if (test_val != expected_val) {
     std::cerr << filename << ':' << linenum << " Expecting " << entity_name
-              << " == \"" << expected_val << "\", but got \"";
-    Syntax_Tags::print(std::cerr, test_val) << "\"\n";
+              << " == \"" << Syntax_Tags::label(expected_val)
+              << "\", but got \"" << Syntax_Tags::label(test_val) << "\"\n";
     return false;
   }
   return true;

--- a/tests/test_parse_type_decl.cc
+++ b/tests/test_parse_type_decl.cc
@@ -33,7 +33,7 @@ bool test_simple() {
     Stmt_Tree st = FLPR::Stmt::type_declaration_stmt(ts);
     TEST_TREE(st, type_declaration_stmt, l);
     auto c = st.ccursor();
-    c.down(3);
+    c.down(4);
     TEST_TAG(c->syntag, KW_DOUBLEPRECISION);
     TEST_INT(c.num_branches(), 2);
     TEST_TOK_EQ(Syntax_Tags::BAD, ts.peek(), l);
@@ -45,7 +45,7 @@ bool test_simple() {
     Stmt_Tree st = FLPR::Stmt::type_declaration_stmt(ts);
     TEST_TREE(st, type_declaration_stmt, l);
     auto c = st.ccursor();
-    c.down(3);
+    c.down(4);
     TEST_TAG(c->syntag, KW_DOUBLEPRECISION);
     TEST_INT(c.num_branches(), 0);
     TEST_TOK_EQ(Syntax_Tags::BAD, ts.peek(), l);

--- a/tests/test_stmt_cover.cc
+++ b/tests/test_stmt_cover.cc
@@ -364,9 +364,13 @@ bool type_declaration_stmt() {
   PARSE(type_declaration_stmt, "integer::f,a");
   auto c{st.cursor()};
   TEST_TAG(c->syntag, SG_TYPE_DECLARATION_STMT);
-  TEST_INT(c.node().num_branches(), 3);
-  // INTEGER
+  TEST_INT(c.node().num_branches(), 2); // type-decl-attr-seq entity-decl-list
   c.down();
+  TEST_TAG(c->syntag, SG_TYPE_DECL_ATTR_SEQ);
+  TEST_INT(c.node().num_branches(), 2);  // "INTEGER" "::"
+  
+  c.down();
+  // INTEGER
   TEST_TAG(c->syntag, SG_DECLARATION_TYPE_SPEC);
   TEST_TRUE(c.has_next());
   TEST_INT(c.node().num_branches(), 1);
@@ -385,6 +389,9 @@ bool type_declaration_stmt() {
   c.next();
   TEST_TAG(c->syntag, TK_DBL_COLON);
   TEST_TRUE(c.is_leaf());
+  TEST_FALSE(c.has_next());
+
+  c.up();
   TEST_TRUE(c.has_next());
   c.next();
 


### PR DESCRIPTION
Restructured _type-declaration-stmt_ parsing to introduce a non-standard _type-decl-attr-seq_ Stmt_Tree node that covers the token range unto the beginning of the first _entity-decl_.  This makes it easier to reproduce the _declaration-type-spec_ + any _attr-spec_.  This commit addresses issue #41.