### PR TITLE
Fixes for flpr-format

### DIFF
--- a/apps/flpr-format.cc
+++ b/apps/flpr-format.cc
@@ -52,7 +52,7 @@ int main(int argc, char *const argv[]) {
     VERBOSE_END;
     /* Define the indentation pattern based on the input format. It would be
        nice if this was setup from an external configuration file */
-    if (file.logical_file().is_fixed_format()) {
+    if (file.logical_file().is_fixed_format() && !options[OPT(FIXED_TO_FREE)]) {
       indents.apply_constant_fixed_indent(4);
       indents.set_continued_offset(5);
     } else {

--- a/apps/flpr-format.cc
+++ b/apps/flpr-format.cc
@@ -60,8 +60,6 @@ int main(int argc, char *const argv[]) {
     }
     if (flpr_format_file(file, options, indents)) {
       std::cerr << "Error formating file \"" << fname << "\"" << std::endl;
-    } else {
-      write_file(std::cout, file);
     }
   }
 }


### PR DESCRIPTION
Fixed a couple of bugs in flpr-format:
* Apply emacs-style indenting if both fixed-to-free and reindent are specified.
* Eliminate duplicate output.