### PR TITLE
Ignore text beyond last specified column in fixed-format

### DIFF
--- a/apps/caliper.cc
+++ b/apps/caliper.cc
@@ -57,7 +57,7 @@ int main(int argc, char const *argv[]) {
 /*--------------------------------------------------------------------------*/
 
 bool caliper_file(std::string const &filename) {
-  File file(filename);
+  File file(filename, 0);
   if (!file)
     return false;
 

--- a/apps/flpr-format.cc
+++ b/apps/flpr-format.cc
@@ -48,7 +48,7 @@ int main(int argc, char *const argv[]) {
   for (auto const &fname : filenames) {
     File file;
     VERBOSE_BEGIN("read_file");
-    file.read_file(fname);
+    file.read_file(fname, 0);
     VERBOSE_END;
     /* Define the indentation pattern based on the input format. It would be
        nice if this was setup from an external configuration file */

--- a/apps/flpr-format.cc
+++ b/apps/flpr-format.cc
@@ -31,6 +31,7 @@ int main(int argc, char *const argv[]) {
   std::vector<std::string> filenames;
   Options options;
   options.enable_all_filters();
+  options[OPT(COL72)] = false;
   options[OPT(FIXED_TO_FREE)] = false;
   options[OPT(REINDENT)] = false;
   if (!parse_cmd_line(filenames, options, argc, argv)) {
@@ -48,7 +49,7 @@ int main(int argc, char *const argv[]) {
   for (auto const &fname : filenames) {
     File file;
     VERBOSE_BEGIN("read_file");
-    file.read_file(fname, 0);
+    file.read_file(fname, options[OPT(COL72)]?72:0);
     VERBOSE_END;
     /* Define the indentation pattern based on the input format. It would be
        nice if this was setup from an external configuration file */

--- a/apps/flpr_format_base.cc
+++ b/apps/flpr_format_base.cc
@@ -203,6 +203,7 @@ void write_file(std::ostream &os, File const &f) {
 
 void print_usage(std::ostream &os) {
   os << "usage: flpr-format [-foqtv] file ...\n";
+  os << "\t-c\ttreat fixed-format input past col 72 as comments\n";
   os << "\t-e\telaborate procedure END statements\n";
   os << "\t-f\tdo fixed-format to free-format conversion\n";
   os << "\t-i\treindent\n";
@@ -215,8 +216,11 @@ void print_usage(std::ostream &os) {
 bool parse_cmd_line(std::vector<std::string> &filenames, Options &options,
                     int argc, char *const argv[]) {
   int ch;
-  while ((ch = getopt(argc, argv, "efioqtv")) != -1) {
+  while ((ch = getopt(argc, argv, "cefioqtv")) != -1) {
     switch (ch) {
+    case 'c':
+      options[Options::COL72] = true;
+      break;
     case 'e':
       options[Options::ELABORATE_END_STMTS] = true;
       break;

--- a/apps/flpr_format_base.hh
+++ b/apps/flpr_format_base.hh
@@ -22,6 +22,7 @@ struct Options {
   enum Filter_Tags : size_t {
     ELABORATE_END_STMTS,
     FIXED_TO_FREE,
+    COL72,
     REINDENT,
     REMOVE_EMPTY_STMTS,
     SPLIT_COMPOUND_STMTS,

--- a/apps/flpr_show_cst.cc
+++ b/apps/flpr_show_cst.cc
@@ -56,7 +56,7 @@ int main() {
 
   switch (file_type) {
   case FLPR::File_Type::FIXEDFMT:
-    scan_okay = logical_file.scan_fixed(raw_lines);
+    scan_okay = logical_file.scan_fixed(raw_lines, 72);
     break;
   case FLPR::File_Type::FREEFMT:
     scan_okay = logical_file.scan_free(raw_lines);

--- a/apps/module.cc
+++ b/apps/module.cc
@@ -74,7 +74,7 @@ int main(int argc, char *argv[]) {
 
   for (std::string const &filename : fortran_filenames) {
     /* you could change to an alternative file_type_from_ext function here */
-    FLPR_Module::do_file(filename, FLPR::file_type_from_extension(filename),
+    FLPR_Module::do_file(filename, 0, FLPR::file_type_from_extension(filename),
                          action);
   }
 

--- a/apps/module_base.cc
+++ b/apps/module_base.cc
@@ -26,10 +26,11 @@ namespace FLPR_Module {
 
 /*--------------------------------------------------------------------------*/
 
-bool do_file(std::string const &filename, FLPR::File_Type file_type,
+bool do_file(std::string const &filename, int const last_fixed_col,
+             FLPR::File_Type file_type,
              Module_Action const &visit_action) {
 
-  File file(filename, file_type);
+  File file(filename, last_fixed_col, file_type);
   if (!file)
     exit(1);
 

--- a/apps/module_base.cc
+++ b/apps/module_base.cc
@@ -27,8 +27,7 @@ namespace FLPR_Module {
 /*--------------------------------------------------------------------------*/
 
 bool do_file(std::string const &filename, int const last_fixed_col,
-             FLPR::File_Type file_type,
-             Module_Action const &visit_action) {
+             FLPR::File_Type file_type, Module_Action const &visit_action) {
 
   File file(filename, last_fixed_col, file_type);
   if (!file)

--- a/apps/module_base.hh
+++ b/apps/module_base.hh
@@ -59,7 +59,8 @@ private:
   std::string module_lc_;
 };
 
-bool do_file(std::string const &filename, FLPR::File_Type file_type,
+bool do_file(std::string const &filename, int const last_fixed_col,
+             FLPR::File_Type file_type,
              Module_Action const &action);
 void write_file(std::ostream &os, File const &f);
 bool has_call_named(FLPR::LL_Stmt const &stmt,

--- a/apps/module_base.hh
+++ b/apps/module_base.hh
@@ -60,8 +60,7 @@ private:
 };
 
 bool do_file(std::string const &filename, int const last_fixed_col,
-             FLPR::File_Type file_type,
-             Module_Action const &action);
+             FLPR::File_Type file_type, Module_Action const &action);
 void write_file(std::ostream &os, File const &f);
 bool has_call_named(FLPR::LL_Stmt const &stmt,
                     std::unordered_set<std::string> const &lowercase_names);

--- a/apps/parse_files.cc
+++ b/apps/parse_files.cc
@@ -52,7 +52,7 @@ bool read_file(std::string const &filename, std::vector<File> &files) {
   File f;
   std::cout << "Processing: '" << filename << "'"
             << "\n\tscanning..." << std::endl;
-  if (!f.logical_file.read_and_scan(filename)) {
+  if (!f.logical_file.read_and_scan(filename,0)) {
     std::cout << "\tread/scan FAILED" << std::endl;
     return false;
   }

--- a/apps/parse_files.cc
+++ b/apps/parse_files.cc
@@ -52,7 +52,7 @@ bool read_file(std::string const &filename, std::vector<File> &files) {
   File f;
   std::cout << "Processing: '" << filename << "'"
             << "\n\tscanning..." << std::endl;
-  if (!f.logical_file.read_and_scan(filename,0)) {
+  if (!f.logical_file.read_and_scan(filename, 0)) {
     std::cout << "\tread/scan FAILED" << std::endl;
     return false;
   }

--- a/src/flpr/File_Info.hh
+++ b/src/flpr/File_Info.hh
@@ -37,6 +37,8 @@ struct File_Info {
   std::string filename;
   //! The language level in this file.
   File_Type file_type;
+  //! If fixed-format, the last column
+  int last_fixed_column = 0;
 };
 
 //! Guess the type of a file from its extension

--- a/src/flpr/File_Line.cc
+++ b/src/flpr/File_Line.cc
@@ -715,12 +715,13 @@ std::string::size_type find_trailing_fixed(
          previous_open_delim == '\'');
 
   const ST N = txt.size();
-  
+
   char char_context = previous_open_delim;
   open_delim = '\0';
 
   /* Truncate lines at the last column, if active */
-  ST const lc = (last_column>0)?std::min(static_cast<ST>(last_column), N):N;
+  ST const lc =
+      (last_column > 0) ? std::min(static_cast<ST>(last_column), N) : N;
   for (ST i = start_idx; i < lc; ++i) {
     const char c = txt[i];
     if (!char_context) {
@@ -738,7 +739,7 @@ std::string::size_type find_trailing_fixed(
     }
   }
   open_delim = char_context;
-  return (lc < N) ? lc+1 : std::string::npos;
+  return (lc < N) ? lc + 1 : std::string::npos;
 }
 
 /* Find trailing continuation and/or comments.  Note that start_idx needs to be

--- a/src/flpr/File_Line.cc
+++ b/src/flpr/File_Line.cc
@@ -739,7 +739,7 @@ std::string::size_type find_trailing_fixed(
     }
   }
   open_delim = char_context;
-  return (lc < N) ? lc + 1 : std::string::npos;
+  return (lc < N) ? lc : std::string::npos;
 }
 
 /* Find trailing continuation and/or comments.  Note that start_idx needs to be

--- a/src/flpr/File_Line.cc
+++ b/src/flpr/File_Line.cc
@@ -177,6 +177,17 @@ File_Line File_Line::analyze_fixed(int const linenum,
   } else {
     main_text = raw_txt.substr(ri, trailing_begin - ri);
     right_text = raw_txt.substr(trailing_begin);
+    if (last_column > 0 && trailing_begin == static_cast<ST>(last_column)) {
+      /* add a comment character if this is some col>72 implicit comment */
+      ST ri = right_text.find_first_not_of(" \t\r");
+      if (ri == std::string::npos) {
+        right_text.clear();
+      } else {
+        if (right_text[ri] != '&' && right_text[ri] != '!') {
+          right_text.insert(0, "! ");
+        }
+      }
+    }
   }
 
   if (main_text.empty()) {

--- a/src/flpr/File_Line.cc
+++ b/src/flpr/File_Line.cc
@@ -34,21 +34,17 @@ bool is_flpr_literal(std::string const &txt,
 
 bool is_flpr_directive(std::string const &txt,
                        std::string::size_type comment_pos);
-std::string::size_type
-find_trailing_fixed(std::string const &txt,
-                    std::string::size_type const start_idx,
-                    char const previous_open_delim, char &open_delim);
+
+std::string::size_type find_trailing_fixed(
+    std::string const &txt, std::string::size_type const start_idx,
+    int const last_column, char const previous_open_delim, char &open_delim);
 
 std::string::size_type
 find_trailing_free(std::string const &txt,
                    std::string::size_type const start_idx,
                    char const previous_open_delim, char &open_delim);
 
-constexpr char filler(bool b, char c) {
-  if (b)
-    return c;
-  return '_';
-}
+constexpr char filler(bool const cond, char const c) { return cond ? c : '_'; }
 
 } // namespace
 
@@ -65,8 +61,10 @@ File_Line::File_Line(const int ln, BITS const &c, std::string const &lt,
 File_Line::File_Line(int ln, BITS const &c, std::string const &lt)
     : linenum(ln), left_txt(lt), open_delim('\0'), classification_(c) {}
 
-File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
-                                   const char prev_open_delim) {
+File_Line File_Line::analyze_fixed(int const linenum,
+                                   std::string const &raw_txt_in,
+                                   char const prev_open_delim,
+                                   int const last_column) {
   using ST = std::string::size_type;
   BITS bits;
   std::string left_text, left_sp, main_text, right_sp, right_text;
@@ -74,7 +72,7 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
   SET_CLASS(fixed_format);
   if (raw_txt_in.empty()) {
     SET_CLASS(blank);
-    return File_Line(ln, bits, raw_txt_in);
+    return File_Line(linenum, bits, raw_txt_in);
   }
 
   // expand tabs in the control columns.  They shouldn't be here,
@@ -98,7 +96,7 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
   ST ri = raw_txt.find_first_not_of(" \t\r");
   if (ri == std::string::npos) {
     SET_CLASS(blank);
-    return File_Line(ln, bits, raw_txt);
+    return File_Line(linenum, bits, raw_txt);
   }
 
   const char c = std::toupper(raw_txt[ri]);
@@ -108,12 +106,12 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
     // Check for standard preprocessor commands
     if (ri == 0 && c == '#') {
       SET_CLASS(preprocessor);
-      return File_Line(ln, bits, raw_txt);
+      return File_Line(linenum, bits, raw_txt);
     }
     // How about a Fortran include directive? (Section 6.4 of the standard)
     if (is_include_line(raw_txt, ri)) {
       SET_CLASS(include);
-      return File_Line(ln, bits, raw_txt);
+      return File_Line(linenum, bits, raw_txt);
     }
     // Look for comment lines (or flpr preprocessor directives)
     if (c == '!' || (ri == 0 && (c == '*' || c == 'C'))) {
@@ -126,9 +124,9 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
         SET_CLASS(flpr_pp);
       else {
         SET_CLASS(comment);
-        return File_Line(ln, bits, raw_txt);
+        return File_Line(linenum, bits, raw_txt);
       }
-      return File_Line(ln, bits, raw_txt);
+      return File_Line(linenum, bits, raw_txt);
     }
   }
 
@@ -159,7 +157,7 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
         ri += 1;
       if (ri == raw_txt.size()) {
         SET_CLASS(blank);
-        return File_Line(ln, bits, raw_txt);
+        return File_Line(linenum, bits, raw_txt);
       }
     }
   }
@@ -171,8 +169,8 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
 
   // We're at the first character of Fortran text.
   char open_delim_char(0);
-  ST trailing_begin =
-      find_trailing_fixed(raw_txt, ri, prev_open_delim, open_delim_char);
+  ST trailing_begin = find_trailing_fixed(raw_txt, ri, last_column,
+                                          prev_open_delim, open_delim_char);
 
   if (trailing_begin == std::string::npos) {
     main_text = raw_txt.substr(ri);
@@ -195,11 +193,11 @@ File_Line File_Line::analyze_fixed(const int ln, std::string const &raw_txt_in,
     }
   }
 
-  return File_Line(ln, bits, left_text, left_sp, main_text, right_sp,
+  return File_Line(linenum, bits, left_text, left_sp, main_text, right_sp,
                    right_text, open_delim_char);
 }
 
-File_Line File_Line::analyze_free(const int ln, std::string const &raw_txt,
+File_Line File_Line::analyze_free(const int linenum, std::string const &raw_txt,
                                   const char prev_open_delim,
                                   const bool prev_line_cont,
                                   bool &in_literal_block) {
@@ -216,13 +214,13 @@ File_Line File_Line::analyze_free(const int ln, std::string const &raw_txt,
       if (is_flpr_literal(raw_txt, ri))
         in_literal_block = false;
     }
-    return File_Line(ln, bits, raw_txt);
+    return File_Line(linenum, bits, raw_txt);
   }
 
   // There isn't one...
   if (std::string::npos == ri) {
     SET_CLASS(blank);
-    return File_Line(ln, bits, raw_txt);
+    return File_Line(linenum, bits, raw_txt);
   }
 
   const char c = std::toupper(raw_txt[ri]);
@@ -230,12 +228,12 @@ File_Line File_Line::analyze_free(const int ln, std::string const &raw_txt,
   // Check for standard preprocessor commands
   if (ri == 0 && c == '#') {
     SET_CLASS(preprocessor);
-    return File_Line(ln, bits, raw_txt);
+    return File_Line(linenum, bits, raw_txt);
   }
   // How about a Fortran include directive? (Section 6.4 of the standard)
   if (is_include_line(raw_txt, ri)) {
     SET_CLASS(include);
-    return File_Line(ln, bits, raw_txt);
+    return File_Line(linenum, bits, raw_txt);
   }
 
   // Look for comment lines (or flpr preprocessor directives)
@@ -251,9 +249,9 @@ File_Line File_Line::analyze_free(const int ln, std::string const &raw_txt,
       if (prev_line_cont)
         SET_CLASS(continued);
       SET_CLASS(comment);
-      return File_Line(ln, bits, trim_back_copy(raw_txt));
+      return File_Line(linenum, bits, trim_back_copy(raw_txt));
     }
-    return File_Line(ln, bits, raw_txt);
+    return File_Line(linenum, bits, raw_txt);
   }
 
   // Now we have a standard Fortran line
@@ -316,7 +314,7 @@ File_Line File_Line::analyze_free(const int ln, std::string const &raw_txt,
   if (right_text.empty())
     right_sp.clear();
 
-  return File_Line(ln, bits, left_text, left_sp, main_text, right_sp,
+  return File_Line(linenum, bits, left_text, left_sp, main_text, right_sp,
                    right_text, open_delim);
 }
 
@@ -709,36 +707,38 @@ bool is_flpr_literal(std::string const &txt,
 
 /* Find trailing comments in fixed format.  Note that start_idx needs to be past
  any prefixed labels, continuations, or control blocks. */
-std::string::size_type
-find_trailing_fixed(std::string const &txt,
-                    std::string::size_type const start_idx,
-                    char const previous_open_delim, char &open_delim) {
+std::string::size_type find_trailing_fixed(
+    std::string const &txt, std::string::size_type const start_idx,
+    int const last_column, char const previous_open_delim, char &open_delim) {
   using ST = std::string::size_type;
   assert(previous_open_delim == '\0' || previous_open_delim == '\"' ||
          previous_open_delim == '\'');
 
   const ST N = txt.size();
+  
   char char_context = previous_open_delim;
   open_delim = '\0';
 
-  for (ST i = start_idx; i < N; ++i) {
+  /* Truncate lines at the last column, if active */
+  ST const lc = (last_column>0)?std::min(static_cast<ST>(last_column), N):N;
+  for (ST i = start_idx; i < lc; ++i) {
     const char c = txt[i];
     if (!char_context) {
       /* Note that you shouldn't use this technique to find the extent of
-         strings, as they are allowed to contain doubled delimiters as escapes.
-         For example: 'Paul''s code' is equivalent to "Paul's code", not two
-         strings.  For our purpose, this doesn't matter. */
+         strings, as they are allowed to contain doubled delimiters as
+         escapes.  For example: 'Paul''s code' is equivalent to "Paul's code",
+         not two strings.  For our purpose, this doesn't matter. */
       if (c == '\'' || c == '"')
         char_context = c;
       else if (c == '!')
         return i;
     } else {
       if (c == char_context)
-        char_context = 0;
+        char_context = '\0';
     }
   }
   open_delim = char_context;
-  return std::string::npos;
+  return (lc < N) ? lc+1 : std::string::npos;
 }
 
 /* Find trailing continuation and/or comments.  Note that start_idx needs to be

--- a/src/flpr/File_Line.hh
+++ b/src/flpr/File_Line.hh
@@ -101,17 +101,22 @@ public:
 
   /*!
     \brief Apportion the text to the different fields assuming fixed-format
-           input.
+           input, ignoring (treat as comment) characters past last_column.
 
     \param[in] linenum         The (index origin = 1) line number in the file
-    \param[in,out] raw_txt     The character data for one file line
+    \param[in] raw_txt         The character data for one file line
     \param[in] prev_open_delim The `open_delim` from the previous File_Line
+    \param[in] last_column     Anything past this column is ignored (0=disable)
   */
-  static File_Line analyze_fixed(const int linenum, std::string const &raw_txt,
-                                 const char prev_open_delim);
+  static File_Line analyze_fixed(int const linenum, std::string const &raw_txt,
+                                 char const prev_open_delim,
+                                 int const last_column);
+
+  //! Simple wrapper for analyze_fixed
   static File_Line analyze_fixed(std::string const &raw_txt,
+                                 int const last_column,
                                  int const linenum = -1) {
-    return analyze_fixed(linenum, raw_txt, '\0');
+    return analyze_fixed(linenum, raw_txt, '\0', last_column);
   }
 
   /*!

--- a/src/flpr/Logical_File.cc
+++ b/src/flpr/Logical_File.cc
@@ -35,6 +35,7 @@ void Logical_File::clear() {
 }
 
 bool Logical_File::read_and_scan(std::string const &filename,
+                                 int const last_fixed_col,
                                  File_Type file_type) {
   std::ifstream is(filename.c_str());
   if (!is) {
@@ -43,7 +44,7 @@ bool Logical_File::read_and_scan(std::string const &filename,
     return false;
   }
 
-  bool res = read_and_scan(is, filename, file_type);
+  bool res = read_and_scan(is, filename, last_fixed_col, file_type);
 
   is.close();
   return res;
@@ -51,23 +52,25 @@ bool Logical_File::read_and_scan(std::string const &filename,
 
 bool Logical_File::read_and_scan(std::istream &is,
                                  std::string const &stream_name,
+                                 int const last_fixed_col,
                                  File_Type stream_type) {
   Line_Buf buf;
   buf.reserve(1024);
   for (std::string line; std::getline(is, line);) {
     buf.push_back(line);
   }
-  return scan(buf, stream_name, stream_type);
+  return scan(buf, stream_name, last_fixed_col, stream_type);
 }
 
 bool Logical_File::scan(Line_Buf const &buf, std::string const &buffer_name,
-                        File_Type buffer_type) {
+                        int const last_fixed_col, File_Type buffer_type) {
   file_info = std::make_shared<File_Info>(buffer_name, buffer_type);
 
   bool res = false;
   switch (file_type()) {
   case File_Type::FIXEDFMT:
-    res = scan_fixed(buf);
+    file_info->last_fixed_column = last_fixed_col;
+    res = scan_fixed(buf, last_fixed_col);
     break;
   case File_Type::FREEFMT:
     res = scan_free(buf);
@@ -80,7 +83,7 @@ bool Logical_File::scan(Line_Buf const &buf, std::string const &buffer_name,
   return res;
 }
 
-bool Logical_File::scan_fixed(Line_Buf const &raw_lines) {
+bool Logical_File::scan_fixed(Line_Buf const &raw_lines, int const last_col) {
   const size_t N = raw_lines.size();
   num_input_lines = N;
   // Convert the raw text input into File_Lines
@@ -89,7 +92,8 @@ bool Logical_File::scan_fixed(Line_Buf const &raw_lines) {
   for (size_t i = 0; i < N; ++i) {
     try {
       fl[i] =
-          File_Line::analyze_fixed((int)i + 1, raw_lines[i], prev_open_delim);
+        File_Line::analyze_fixed((int)i + 1, raw_lines[i], prev_open_delim,
+                                 last_col);
     } catch (std::exception &e) {
       std::cerr << "At line " << i + 1 << " of \"" << file_info->filename
                 << "\":\n"

--- a/src/flpr/Logical_File.cc
+++ b/src/flpr/Logical_File.cc
@@ -91,9 +91,8 @@ bool Logical_File::scan_fixed(Line_Buf const &raw_lines, int const last_col) {
   char prev_open_delim = '\0';
   for (size_t i = 0; i < N; ++i) {
     try {
-      fl[i] =
-        File_Line::analyze_fixed((int)i + 1, raw_lines[i], prev_open_delim,
-                                 last_col);
+      fl[i] = File_Line::analyze_fixed((int)i + 1, raw_lines[i],
+                                       prev_open_delim, last_col);
     } catch (std::exception &e) {
       std::cerr << "At line " << i + 1 << " of \"" << file_info->filename
                 << "\":\n"

--- a/src/flpr/Logical_File.hh
+++ b/src/flpr/Logical_File.hh
@@ -44,18 +44,21 @@ public:
 
   //! Read in the contents of the named file and scan
   bool read_and_scan(std::string const &filename,
+                     int const last_fixed_col,
                      File_Type file_type = File_Type::UNKNOWN);
 
   //! Read in the contents of a stream and scan
   bool read_and_scan(std::istream &is, std::string const &stream_name,
+                     int const last_fixed_col,
                      File_Type file_type = File_Type::UNKNOWN);
 
   //! Scan a list of raw lines
   bool scan(Line_Buf const &line_buffer, std::string const &buffer_name,
-            File_Type file_type = File_Type::UNKNOWN);
+            int const last_fixed_col, File_Type file_type = File_Type::UNKNOWN);
 
   //! Scan the file assuming F77-style fixed format
-  bool scan_fixed(Line_Buf const &fl);
+  bool scan_fixed(Line_Buf const &fl, int const last_col);
+
   //! Scan the file assuming F90-style free format
   bool scan_free(Line_Buf const &fl);
 

--- a/src/flpr/Logical_File.hh
+++ b/src/flpr/Logical_File.hh
@@ -43,8 +43,7 @@ public:
   ~Logical_File() = default;
 
   //! Read in the contents of the named file and scan
-  bool read_and_scan(std::string const &filename,
-                     int const last_fixed_col,
+  bool read_and_scan(std::string const &filename, int const last_fixed_col,
                      File_Type file_type = File_Type::UNKNOWN);
 
   //! Read in the contents of a stream and scan

--- a/src/flpr/Logical_Line.cc
+++ b/src/flpr/Logical_Line.cc
@@ -73,15 +73,14 @@ Logical_Line::Logical_Line(std::string const &raw_text) {
 /* ------------------------------------------------------------------------ */
 Logical_Line::Logical_Line(std::vector<std::string> const &raw_text) {
   clear();
-  
+
   char prev_open_delim = '\0';
   bool prev_line_cont = false;
   int line_no = 1;
   bool in_literal_block{false};
   for (auto const &l : raw_text) {
-    layout_.emplace_back(File_Line::analyze_free(line_no++, l, prev_open_delim,
-                                                 prev_line_cont,
-                                                 in_literal_block));
+    layout_.emplace_back(File_Line::analyze_free(
+        line_no++, l, prev_open_delim, prev_line_cont, in_literal_block));
     prev_open_delim = layout_.back().open_delim;
     prev_line_cont = layout_.back().is_continued();
   }

--- a/src/flpr/Logical_Line.hh
+++ b/src/flpr/Logical_Line.hh
@@ -82,15 +82,19 @@ public:
     init_from_layout();
   }
 
-  //! Make a trivial Logical_Line from a raw string
-  explicit Logical_Line(std::string const &raw_text,
-                        bool const free_format = true);
+  //! Make a trivial Logical_Line from a free-format raw string
+  explicit Logical_Line(std::string const &raw_text);
 
-  //! Make a complicated Logical_Line from a vector of strings
+  //! Make a complicated Logical_Line from a vector of free-format strings
   /*! You can use the std::vector initializer_list constructor to easily use
     this constructor. */
-  explicit Logical_Line(std::vector<std::string> const &raw_text,
-                        bool const free_format = true);
+  explicit Logical_Line(std::vector<std::string> const &raw_text);
+
+  //! Make a trivial Logical_Line from a fixed-format raw string
+  Logical_Line(std::string const &raw_text, int const last_col);
+
+  //! Make a complicated Logical_Line from a vector of fixed-format strings
+  Logical_Line(std::vector<std::string> const &raw_text, int const last_col);
 
   //! Resets the contents
   void clear() noexcept;

--- a/src/flpr/Parsed_File.hh
+++ b/src/flpr/Parsed_File.hh
@@ -42,6 +42,7 @@ public:
       created.  The file is consumed by the time this call returns. The filename
       will be parsed for File_Type extensions IF file_type is not specified. */
   Parsed_File(std::string const &filename,
+              int const last_fixed_col,
               File_Type file_type = File_Type::UNKNOWN);
 
   //! Read and scan an std::istream
@@ -51,6 +52,7 @@ public:
       stream_name will be parsed for File_Type extensions IF stream_type is not
       specified.*/
   explicit Parsed_File(std::istream &is, std::string const &stream_name,
+                       int const last_fixed_col,
                        File_Type stream_type = File_Type::UNKNOWN);
 
   Parsed_File() = default;
@@ -60,6 +62,7 @@ public:
   Parsed_File &operator=(Parsed_File const &) = delete;
 
   bool read_file(std::string const &filename,
+                 int const last_fixed_col,
                  File_Type file_type = File_Type::UNKNOWN);
 
   constexpr operator bool() const noexcept { return !bad_state_; }
@@ -137,8 +140,9 @@ private:
 
 template <typename PG_NODE_DATA>
 Parsed_File<PG_NODE_DATA>::Parsed_File(std::string const &filename,
+                                       int const last_fixed_col,
                                        File_Type file_type) {
-  if (logical_file_.read_and_scan(filename, file_type)) {
+  if (logical_file_.read_and_scan(filename, last_fixed_col, file_type)) {
     bad_state_ = false;
   }
 }
@@ -146,18 +150,20 @@ Parsed_File<PG_NODE_DATA>::Parsed_File(std::string const &filename,
 template <typename PG_NODE_DATA>
 Parsed_File<PG_NODE_DATA>::Parsed_File(std::istream &is,
                                        std::string const &stream_name,
+                                       int const last_fixed_col,
                                        File_Type stream_type)
     : from_stream_{true} {
-  if (logical_file_.read_and_scan(is, stream_name, stream_type)) {
+  if (logical_file_.read_and_scan(is, stream_name, last_fixed_col, stream_type)) {
     bad_state_ = false;
   }
 }
 
 template <typename PG_NODE_DATA>
 bool Parsed_File<PG_NODE_DATA>::read_file(std::string const &filename,
+                                          int const last_fixed_col,
                                           File_Type file_type) {
   assert(bad_state_);
-  if (logical_file_.read_and_scan(filename, file_type)) {
+  if (logical_file_.read_and_scan(filename, last_fixed_col, file_type)) {
     bad_state_ = false;
   }
   return bad_state_;

--- a/src/flpr/Parsed_File.hh
+++ b/src/flpr/Parsed_File.hh
@@ -41,8 +41,7 @@ public:
       Logical_Lines, accessable as `logical_lines()`.  No other structures are
       created.  The file is consumed by the time this call returns. The filename
       will be parsed for File_Type extensions IF file_type is not specified. */
-  Parsed_File(std::string const &filename,
-              int const last_fixed_col,
+  Parsed_File(std::string const &filename, int const last_fixed_col,
               File_Type file_type = File_Type::UNKNOWN);
 
   //! Read and scan an std::istream
@@ -61,8 +60,7 @@ public:
   Parsed_File &operator=(Parsed_File &&) = default;
   Parsed_File &operator=(Parsed_File const &) = delete;
 
-  bool read_file(std::string const &filename,
-                 int const last_fixed_col,
+  bool read_file(std::string const &filename, int const last_fixed_col,
                  File_Type file_type = File_Type::UNKNOWN);
 
   constexpr operator bool() const noexcept { return !bad_state_; }
@@ -153,7 +151,8 @@ Parsed_File<PG_NODE_DATA>::Parsed_File(std::istream &is,
                                        int const last_fixed_col,
                                        File_Type stream_type)
     : from_stream_{true} {
-  if (logical_file_.read_and_scan(is, stream_name, last_fixed_col, stream_type)) {
+  if (logical_file_.read_and_scan(is, stream_name, last_fixed_col,
+                                  stream_type)) {
     bad_state_ = false;
   }
 }

--- a/src/flpr/Prgm_Parsers.hh
+++ b/src/flpr/Prgm_Parsers.hh
@@ -14,8 +14,8 @@
 #ifndef FLPR_PRGM_PARSERS_HH
 #define FLPR_PRGM_PARSERS_HH 1
 
-#include "flpr/Label_Stack.hh"
 #include "flpr/LL_Stmt.hh"
+#include "flpr/Label_Stack.hh"
 #include "flpr/Parser_Result.hh"
 #include "flpr/Prgm_Tree.hh"
 #include "flpr/Tree.hh"
@@ -95,7 +95,6 @@ template <typename Node_Data = Prgm_Node_Data> struct Parsers {
   static PP_Result where_construct(State &state);
 
 #include "Prgm_Parsers_utils.hh"
-
 };
 
 #include "Prgm_Parsers_impl.hh"

--- a/tests/LL_Helper.cc
+++ b/tests/LL_Helper.cc
@@ -11,12 +11,14 @@
 #include "LL_Helper.hh"
 #include "parse_helpers.hh"
 
-LL_Helper::LL_Helper(Raw_Lines &&buf, const bool is_free_format) noexcept {
-  if (is_free_format) {
-    text_.scan_free(buf);
-  } else {
-    text_.scan_fixed(buf);
-  }
+LL_Helper::LL_Helper(Raw_Lines &&buf) noexcept {
+  text_.scan_free(buf);
+  assert(!text_.lines.empty());
+  text_.make_stmts();
+}
+
+LL_Helper::LL_Helper(Raw_Lines &&buf, int const last_col) noexcept {
+  text_.scan_fixed(buf, last_col);
   assert(!text_.lines.empty());
   text_.make_stmts();
 }

--- a/tests/LL_Helper.hh
+++ b/tests/LL_Helper.hh
@@ -24,7 +24,8 @@ FLPR::TT_Stream for the first statement. */
 class LL_Helper {
 public:
   using Raw_Lines = FLPR::Logical_File::Line_Buf;
-  LL_Helper(Raw_Lines &&buf, const bool is_free_format = true) noexcept;
+  explicit LL_Helper(Raw_Lines &&buf) noexcept;
+  LL_Helper(Raw_Lines &&buf, int const last_col) noexcept;
   //! Return a TT_Stream for the first statement
   FLPR::TT_Stream stream1() noexcept {
     return FLPR::TT_Stream{text_.ll_stmts.front()};

--- a/tests/test_file_line.cc
+++ b/tests/test_file_line.cc
@@ -19,7 +19,7 @@ using FLPR::File_Line;
 bool fixed_blank1() {
   //              "123456"
   std::string str("");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_blank());
   TEST_TRUE(fl.is_trivial());
   TEST_FALSE(fl.is_fortran());
@@ -29,7 +29,7 @@ bool fixed_blank1() {
 bool fixed_blank2() {
   //              "123456"
   std::string str("  ");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_blank());
   TEST_TRUE(fl.is_trivial());
   TEST_FALSE(fl.is_fortran());
@@ -39,7 +39,7 @@ bool fixed_blank2() {
 bool fixed_blank3() {
   //              "123456"
   std::string str("             \t");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_blank());
   TEST_TRUE(fl.is_trivial());
   TEST_FALSE(fl.is_fortran());
@@ -49,7 +49,7 @@ bool fixed_blank3() {
 bool fixed_comment1() {
   //              "123456"
   std::string str("C     This is an aligned comment");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_comment());
   TEST_TRUE(fl.is_trivial());
   TEST_FALSE(fl.is_fortran());
@@ -59,7 +59,7 @@ bool fixed_comment1() {
 bool fixed_comment2() {
   //              "123456"
   std::string str("c     This is an aligned comment");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_comment());
   TEST_FALSE(fl.is_fortran());
   return true;
@@ -68,7 +68,7 @@ bool fixed_comment2() {
 bool fixed_comment3() {
   //              "123456"
   std::string str("!     This is an aligned comment");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_comment());
   TEST_FALSE(fl.is_fortran());
   return true;
@@ -77,7 +77,7 @@ bool fixed_comment3() {
 bool fixed_comment4() {
   //              "123456"
   std::string str("  !     This is an aligned comment");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_comment());
   TEST_FALSE(fl.is_fortran());
   return true;
@@ -86,7 +86,7 @@ bool fixed_comment4() {
 bool fixed_comment5() {
   //              "123456"
   std::string str("       !     This is an aligned comment");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_comment());
   TEST_FALSE(fl.is_fortran());
   return true;
@@ -95,7 +95,7 @@ bool fixed_comment5() {
 bool fixed_flprpp() {
   //              "123456"
   std::string str("!#flpr ");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_FALSE(fl.is_comment());
   TEST_TRUE(fl.is_flpr_pp());
   TEST_FALSE(fl.is_fortran());
@@ -105,7 +105,7 @@ bool fixed_flprpp() {
 bool fixed_labelled() {
   //              "123456"
   std::string str(" 100  continue");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_fortran());
   TEST_TRUE(fl.has_label());
   TEST_STR(" 100", fl.left_txt);
@@ -116,7 +116,7 @@ bool fixed_labelled() {
 bool fixed_indent() {
   //              "123456"
   std::string str("        call foo()");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_fortran());
   TEST_FALSE(fl.has_label());
   TEST_STR("", fl.left_txt);
@@ -128,7 +128,7 @@ bool fixed_indent() {
 bool fixed_continuation() {
   //              "123456"
   std::string str("     a   call foo()");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_fortran());
   TEST_FALSE(fl.has_label());
   TEST_TRUE(fl.is_continuation());
@@ -144,7 +144,7 @@ bool fixed_not_a_continuation() {
   /* section 6.3.3.3 points out that a '0' in col 6 is not a continuation */
   //              "123456"
   std::string str("     0   call foo()");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_fortran());
   TEST_FALSE(fl.has_label());
   TEST_FALSE(fl.is_continuation());
@@ -159,7 +159,7 @@ bool fixed_not_a_continuation() {
 bool fixed_trailing_comment() {
   //              "123456"
   std::string str("        call foo() ! trailing ");
-  File_Line fl = File_Line::analyze_fixed(1, str, '\0');
+  File_Line fl = File_Line::analyze_fixed(1, str, '\0', 0);
   TEST_TRUE(fl.is_fortran());
   TEST_FALSE(fl.is_blank());
   TEST_FALSE(fl.has_label());

--- a/tests/test_logical_line.cc
+++ b/tests/test_logical_line.cc
@@ -599,6 +599,22 @@ bool continued_if_fixed_string() {
   return true;
 }
 
+bool continued_if_fixed_trunc_string() {
+  Logical_Line ll(
+      /* Note that this is a vector of two strings, the first being split
+         across two lines of input */
+      std::vector<std::string>{"      print *,                          "
+                                 "                            'abcXXX",
+                               "     1def'"},
+      72);
+  /* Note that we do NOT accept text beyond column 72 in this example */
+  TEST_INT(ll.fragments().size(), 4);
+  FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
+  std::advance(curr, 3);
+  TEST_STR("'abcdef'", curr->text());
+  return true;
+}
+
 int main() {
   TEST_MAIN_DECL;
   TEST(test_default_ctor);
@@ -625,5 +641,6 @@ int main() {
   TEST(replace_main_2);
   TEST(continued_if);
   TEST(continued_if_fixed_string);
+  TEST(continued_if_fixed_trunc_string);
   TEST_MAIN_REPORT;
 }

--- a/tests/test_logical_line.cc
+++ b/tests/test_logical_line.cc
@@ -50,7 +50,7 @@ bool test_simple_1() {
 }
 
 bool offsets_1() {
-  Logical_Line ll("call bar()", true);
+  Logical_Line ll("call bar()");
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->main_txt_line(), 0);
   TEST_INT(curr->main_txt_col(), 0);
@@ -71,7 +71,7 @@ bool offsets_1() {
 }
 
 bool offsets_2() {
-  Logical_Line ll("      call bar()", true);
+  Logical_Line ll("      call bar()");
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->main_txt_col(), 0);
   TEST_INT(curr->start_pos, 7);
@@ -88,7 +88,7 @@ bool offsets_2() {
 }
 
 bool offsets_3() {
-  Logical_Line ll("10    call bar()", true);
+  Logical_Line ll("10    call bar()");
   TEST_INT(ll.label, 10);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->start_pos, 7);
@@ -102,7 +102,7 @@ bool offsets_3() {
 }
 
 bool offsets_4() {
-  Logical_Line ll("   10 call bar()", true);
+  Logical_Line ll("   10 call bar()");
   TEST_INT(ll.label, 10);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->start_pos, 7);
@@ -116,7 +116,7 @@ bool offsets_4() {
 }
 
 bool offsets_5() {
-  Logical_Line ll("       10 call bar()", true);
+  Logical_Line ll("       10 call bar()");
   TEST_INT(ll.label, 10);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->start_pos, 11);
@@ -130,7 +130,7 @@ bool offsets_5() {
 }
 
 bool offsets_6() {
-  Logical_Line ll("      call bar()", false);
+  Logical_Line ll("      call bar()", 0);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->start_pos, 7);
   std::advance(curr, 1);
@@ -143,7 +143,7 @@ bool offsets_6() {
 }
 
 bool offsets_7() {
-  Logical_Line ll("10    call bar()", false);
+  Logical_Line ll("10    call bar()", 0);
   TEST_INT(ll.label, 10);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->start_pos, 7);
@@ -157,7 +157,7 @@ bool offsets_7() {
 }
 
 bool offsets_8() {
-  Logical_Line ll("   10 call bar()", false);
+  Logical_Line ll("   10 call bar()", 0);
   TEST_INT(ll.label, 10);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   TEST_INT(curr->start_pos, 7);
@@ -171,7 +171,7 @@ bool offsets_8() {
 }
 
 bool replace_fragment_1() {
-  Logical_Line ll("   call bar()", true);
+  Logical_Line ll("   call bar()");
   FLPR::TT_SEQ::iterator name = std::next(ll.fragments().begin());
   TEST_STR("bar", name->text());
   ll.replace_fragment(name, FLPR::Syntax_Tags::TK_NAME,
@@ -197,7 +197,7 @@ bool replace_fragment_1() {
 }
 
 bool replace_fragment_2() {
-  Logical_Line ll("   call bar()", true);
+  Logical_Line ll("   call bar()");
   FLPR::TT_SEQ::iterator name = std::next(ll.fragments().begin());
   TEST_STR("bar", name->text());
   ll.replace_fragment(name, FLPR::Syntax_Tags::TK_NAME, std::string{"b"});
@@ -222,7 +222,7 @@ bool replace_fragment_2() {
 }
 
 bool split_after_0() {
-  Logical_Line ll("   call bar  ! comment", true);
+  Logical_Line ll("   call bar  ! comment");
   Logical_Line remain;
 
   FLPR::TT_SEQ::iterator tt = std::next(ll.fragments().begin());
@@ -244,7 +244,7 @@ bool split_after_0() {
 }
 
 bool split_after_1() {
-  Logical_Line ll("call bar", true);
+  Logical_Line ll("call bar");
   Logical_Line remain;
 
   FLPR::TT_SEQ::iterator tt = ll.fragments().begin();
@@ -279,7 +279,7 @@ bool split_after_1() {
 }
 
 bool split_after_2() {
-  Logical_Line ll("call  bar    ! foo", true);
+  Logical_Line ll("call  bar    ! foo");
   Logical_Line remain;
 
   FLPR::TT_SEQ::iterator tt = ll.fragments().begin();
@@ -314,7 +314,7 @@ bool split_after_2() {
 }
 
 bool split_after_3() {
-  Logical_Line ll("   call  bar    ! foo", true);
+  Logical_Line ll("   call  bar    ! foo");
   Logical_Line remain;
 
   FLPR::TT_SEQ::iterator tt = ll.fragments().begin();
@@ -348,7 +348,7 @@ bool split_after_3() {
 }
 
 bool split_after_4() {
-  Logical_Line ll(" 2 call  bar    ! foo", true);
+  Logical_Line ll(" 2 call  bar    ! foo");
   Logical_Line remain;
 
   FLPR::TT_SEQ::iterator tt = ll.fragments().begin();
@@ -383,7 +383,7 @@ bool split_after_4() {
 }
 
 bool split_after_5() {
-  Logical_Line ll("   call bar;a=a+1!hey", true);
+  Logical_Line ll("   call bar;a=a+1!hey");
   Logical_Line remain;
 
   FLPR::TT_SEQ::iterator tt = std::next(ll.fragments().begin());
@@ -571,7 +571,7 @@ bool continued_if() {
   Logical_Line ll(
       std::vector<std::string>{"                if ( a(b)%c(d) < e ) exit",
                                "     &            f"},
-      false);
+      0);
 
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();
   std::advance(curr, 14);
@@ -585,10 +585,12 @@ bool continued_if() {
 
 bool continued_if_fixed_string() {
   Logical_Line ll(
+      /* Note that this is a vector of two strings, the first being split
+         across two lines of input */
       std::vector<std::string>{"      print *,                                 "
                                "                     'abcXXX",
                                "     1def'"},
-      false);
+      0);
   /* Note that we accept text beyond column 72 */
   TEST_INT(ll.fragments().size(), 4);
   FLPR::TT_SEQ::const_iterator curr = ll.cfragments().begin();


### PR DESCRIPTION
This PR address issue #60 by treating everything past a specified last_column index as a comment in fixed format.  This is used for parsing very old fixed-format Fortran.  If last_column is specified as '0', this constraint is disabled.