### PR TITLE
Propagate insert_text_after out to Procedure

### DIFF
--- a/src/flpr/Logical_File.cc
+++ b/src/flpr/Logical_File.cc
@@ -435,6 +435,18 @@ void Logical_File::replace_stmt_substr(LL_STMT_SEQ::iterator stmt,
   stmt->unhook();
 }
 
+void Logical_File::insert_text_after(LL_STMT_SEQ::iterator stmt,
+                                     TT_SEQ::iterator frag,
+                                     std::string const &new_text) {
+  auto const frag_off = std::distance(stmt->begin(), frag);
+  isolate_stmt(stmt);
+  auto new_frag_it = std::next(stmt->ll().fragments().begin(), frag_off);
+  stmt->ll().insert_text_after(new_frag_it, new_text);
+  stmt->assign_range(stmt->ll().stmts()[0]);
+  stmt->drop_stmt_tree();
+  stmt->unhook();
+}
+
 void Logical_File::append_stmt_text(LL_STMT_SEQ::iterator stmt,
                                     std::string const &new_text) {
   /* put the stmt on its own line */

--- a/src/flpr/Logical_File.hh
+++ b/src/flpr/Logical_File.hh
@@ -102,6 +102,10 @@ public:
                            LL_TT_Range const &orig_tt,
                            std::string const &new_txt);
 
+  //! Insert some text after a fragment and regen
+  void insert_text_after(LL_STMT_SEQ::iterator stmt, TT_SEQ::iterator frag,
+                         std::string const &new_text);
+
   //! Append some text to the end of stmt and regen
   void append_stmt_text(LL_STMT_SEQ::iterator stmt,
                         std::string const &new_text);

--- a/src/flpr/Procedure.hh
+++ b/src/flpr/Procedure.hh
@@ -196,6 +196,12 @@ public:
     file_.logical_file().replace_stmt_substr(pos, token_range, new_text);
   }
 
+  //! Insert new text after a fragment
+  void insert_text_after(Region_Iterator pos, TT_SEQ::iterator frag,
+                         std::string const &new_text) {
+    file_.logical_file().insert_text_after(pos, frag, new_text);
+  }
+
 public:
   //! An LL_Stmt iterator augmented with a Region_Tag
   class Region_Iterator : public Stmt_Iterator {


### PR DESCRIPTION
Allow easy insertion of raw text after a fragment in a Procedure stmt