### PR TITLE
Fix lexer definitions for real-literal-constant

### DIFF
--- a/src/flpr/Token_Text.hh
+++ b/src/flpr/Token_Text.hh
@@ -63,6 +63,8 @@ public:
   /************* Accessors for testing purposes only *******************/
   int main_txt_line() const noexcept { return mt_begin_line_; }
   int main_txt_col() const noexcept { return mt_begin_col_; }
+  int main_txt_eline() const noexcept { return mt_end_line_; }
+  int main_txt_ecol() const noexcept { return mt_end_col_; }
 
 private:
   std::string text_;          //!< The matched text (lexeme)

--- a/src/flpr/parse_stmt.cc
+++ b/src/flpr/parse_stmt.cc
@@ -3048,7 +3048,6 @@ Stmt_Tree real_literal_constant(TT_Stream &ts) {
     seq(rule_tag,
         TOK(SG_SIGNIFICAND),
         opt(h_seq(TOK(SG_EXPONENT_LETTER),
-                  opt(rule(sign)),
                   TOK(SG_EXPONENT))),
         opt(h_seq(TOK(TK_UNDERSCORE),
                   TOK(SG_KIND_PARAM)))

--- a/src/flpr/scan_fort.l
+++ b/src/flpr/scan_fort.l
@@ -236,10 +236,8 @@ write { return Syntax_Tags::KW_WRITE; }
 
 
 <exp_parse>{
-  e|d      { return Syntax_Tags::SG_EXPONENT_LETTER; }
-  "+"      { return Syntax_Tags::TK_PLUS; }
-  "-"      { return Syntax_Tags::TK_MINUS; }
-  {DIGIT}+ { yy_pop_state(); return Syntax_Tags::SG_EXPONENT; }
+  e|d           { return Syntax_Tags::SG_EXPONENT_LETTER; }
+  [-+]?{DIGIT}+ { yy_pop_state(); return Syntax_Tags::SG_EXPONENT; }
 }
 
 <kind_parse>{
@@ -255,16 +253,22 @@ write { return Syntax_Tags::KW_WRITE; }
 <real_parse>{
   {SIGNIFICAND}  { return Syntax_Tags::SG_SIGNIFICAND;  }
   {DIGIT}+       { return Syntax_Tags::SG_SIGNIFICAND;  }
-  {EXPONENT}     { yyless(0); yy_push_state(exp_parse);  }
-  _{KIND}        { yyless(0); yy_push_state(kind_parse); }
-  .|\n           { yyless(0);  BEGIN(INITIAL); }
+  {EXPONENT}     { curr_line_pos -= yyleng; 
+                   yyless(0);
+                   yy_push_state(exp_parse);  }
+  _{KIND}        { curr_line_pos -= yyleng;
+                   yyless(0); yy_push_state(kind_parse); }
+  .|\n           { curr_line_pos -= yyleng;
+                   yyless(0);  BEGIN(INITIAL); }
 }
 
   /* R714: real-literal-constant (7.4.3.2) */
   /* significand [exponent-letter exponent] [_ kind-param] */
-{SIGNIFICAND}{EXPONENT}?(_{KIND})?   { yyless(0); BEGIN(real_parse); }
+{SIGNIFICAND}{EXPONENT}?(_{KIND})?   { curr_line_pos -= yyleng;
+                                       yyless(0); BEGIN(real_parse); }
   /* digit-string exponent-letter exponent [_ kind-param] */
-{DIGIT}+{EXPONENT}(_{KIND})?  { yyless(0); BEGIN(real_parse); }
+{DIGIT}+{EXPONENT}(_{KIND})?  { curr_line_pos -= yyleng; 
+                                yyless(0); BEGIN(real_parse); }
   				  
   /* R708: int-literal-constant (7.4.3.1) */
 {DIGIT}+(_{KIND})?   { return Syntax_Tags::SG_INT_LITERAL_CONSTANT; }

--- a/tests/test_stmt_cover.cc
+++ b/tests/test_stmt_cover.cc
@@ -448,6 +448,59 @@ bool type_declaration_stmt() {
   return true;
 }
 
+bool real_literal_constant() {
+  PARSE(assignment_stmt, "a=11.e-50_d_p");
+  auto c{st.cursor()};
+  TEST_INT(c.num_branches(), 3);
+  c.down();
+  c.next(2);
+  TEST_TAG(c->syntag, SG_EXPR);
+  TEST_INT(c.num_branches(), 1);
+  c.down();
+  TEST_TAG(c->syntag, SG_REAL_LITERAL_CONSTANT);
+  TEST_INT(c.num_branches(), 5);
+  TEST_INT(c->token_range.size(), 5);
+  TEST_EQ(&(FIRST_LL), &(l.lines().front()));
+  TEST_EQ(&(c->token_range.ll()), &(l.lines().front()));
+  auto tr_it = c->token_range.begin();
+  TEST_TAG(tr_it->token, SG_SIGNIFICAND);
+  TEST_STR("11.", tr_it->text());
+  TEST_INT(tr_it->main_txt_line(), 0);
+  TEST_INT(tr_it->main_txt_eline(), 0);
+  TEST_INT(tr_it->main_txt_col(), 2);
+  TEST_INT(tr_it->main_txt_ecol(), 5);
+  ++tr_it;
+  TEST_TAG(tr_it->token, SG_EXPONENT_LETTER);
+  TEST_STR("e", tr_it->text());
+  TEST_INT(tr_it->main_txt_line(), 0);
+  TEST_INT(tr_it->main_txt_eline(), 0);
+  TEST_INT(tr_it->main_txt_col(), 5);
+  TEST_INT(tr_it->main_txt_ecol(), 6);
+  ++tr_it;
+  TEST_TAG(tr_it->token, SG_EXPONENT);
+  TEST_STR("-50", tr_it->text());
+  TEST_INT(tr_it->main_txt_line(), 0);
+  TEST_INT(tr_it->main_txt_eline(), 0);
+  TEST_INT(tr_it->main_txt_col(), 6);
+  TEST_INT(tr_it->main_txt_ecol(), 9);
+  ++tr_it;
+  TEST_TAG(tr_it->token, TK_UNDERSCORE);
+  TEST_STR("_", tr_it->text());
+  TEST_INT(tr_it->main_txt_line(), 0);
+  TEST_INT(tr_it->main_txt_eline(), 0);
+  TEST_INT(tr_it->main_txt_col(), 9);
+  TEST_INT(tr_it->main_txt_ecol(), 10);
+  ++tr_it;
+  TEST_TAG(tr_it->token, SG_KIND_PARAM);
+  TEST_STR("d_p", tr_it->text());
+  TEST_INT(tr_it->main_txt_line(), 0);
+  TEST_INT(tr_it->main_txt_eline(), 0);
+  TEST_INT(tr_it->main_txt_col(), 10);
+  TEST_INT(tr_it->main_txt_ecol(), 13);
+
+  return true;
+}
+
 int main() {
   TEST_MAIN_DECL;
   TEST(one_tok);
@@ -456,5 +509,6 @@ int main() {
   TEST(opt_tok);
   TEST(function_stmt);
   TEST(type_declaration_stmt);
+  TEST(real_literal_constant);
   TEST_MAIN_REPORT;
 }


### PR DESCRIPTION
This fixes a couple of issues with the scanner and parser definitions for *real-literal-constant*